### PR TITLE
Update node_helper.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,58 @@
-# Magic Mirror Module: ISS Fly-Overs
+# MMM-ISS
 
-This modules for the [Magic Mirror²](https://github.com/MichMich/MagicMirror) will show a card when there's an ISS flyover with a good possibility of viewing.
+A [MagicMirror²](https://github.com/MichMich/MagicMirror) module that displays the next visible pass of the International Space Station (ISS) overhead.
 
-![The Module](.github/ISS-SS.png)
+> **Note:** This module previously used NASA's SpotTheStation service, which was shut down on June 12, 2025. It now uses the [N2YO API](https://www.n2yo.com/api/) instead. A free API key is required.
 
-**This is v1.0** -- and, as the module does what I want, won't likely change much. 
+## Screenshot
 
-## Why?
-Why another ISS module when mykle1 [has already created one](https://github.com/mykle1/MMM-ISS) that works fine?  Well, personal preference.  I didn't like the NASA
-widget look compared to the aesthetics of the rest of my mirror.  Plus, the APIs mykle1 is using (or rather, [the APIs that the APIs are using](https://github.com/open-notify/Open-Notify-API)) are slated to be shut down (see the first output line of [the old spaceflight](https://spaceflight.nasa.gov/realdata/sightings/SSapplications/Post/JavaSSOP/orbit/ISS/SVPOST.html) page).
+![MMM-ISS Screenshot](screenshot.png)
 
-So, here we are.
+## Installation
 
-NB: The `minElevation` property will filter out any sighting whose `Max Elevation` is below your `minElevation` value; the default is 40 degrees.
-When there are no sightings, the panel is hidden.  I find this useful because MM is generally quite static.  Having the panel shown only when there are viewable sightings draws attention when it is present.
+```bash
+cd ~/MagicMirror/modules
+git clone https://github.com/daterrell/MMM-ISS
+cd MMM-ISS
+npm install
+```
 
-## How?
-### Manual install
+## N2YO API Key
 
-1. Clone this repository in your `modules` folder, and install dependencies:
-  ```bash
-  cd ~/MagicMirror/modules # adapt directory if you are using a different one
-  git clone https://github.com/daterrell/MMM-ISS.git
-  cd MMM-ISS
-  npm install
-  ```
-2. Add the module to your `config/config.js` file.
-  ```js
-  {
-    module: 'MMM-ISS',
-    position: 'bottom_center',
-    config: {
-      // These values must come from available locations on the SpotTheStation site: https://spotthestation.nasa.gov/
-      country: "United States",
-      region: "Massachusetts",
-      city: "Boston",
-      minElevation: 40 // Lowest elevation for the panel to show up
-    }
-  },
-  ```
+1. Register for a free account at [n2yo.com](https://www.n2yo.com/login/register/)
+2. Your API key will be shown on your [account page](https://www.n2yo.com/login/)
+3. The free tier allows up to 1,000 requests per hour, which is more than enough for this module
+
+## Configuration
+
+Add the following to your `config.js`:
+
+```javascript
+{
+  module: "MMM-ISS",
+  position: "bottom_right",
+  config: {
+    apiKey: "YOUR_N2YO_API_KEY",  // Required – get yours at n2yo.com
+    lat: 37.77,                    // Your latitude
+    lng: -122.41,                  // Your longitude
+    alt: 0,                        // Your altitude in meters (optional, default: 0)
+    days: 10,                      // How many days ahead to search (optional, default: 10)
+    minElevation: 40               // Minimum elevation in degrees (optional, default: 40)
+  }
+},
+```
+
+### Configuration Options
+
+| Option | Description | Default |
+|---|---|---|
+| `apiKey` | **Required.** Your N2YO API key | — |
+| `lat` | Your latitude | `0` |
+| `lng` | Your longitude | `0` |
+| `alt` | Your altitude in meters | `0` |
+| `days` | Number of days ahead to search for passes | `10` |
+| `minElevation` | Minimum pass elevation in degrees (0–90). Higher values show only more visible passes | `40` |
+
+## License
+
+MIT — By Dave Terrell

--- a/node_helper.js
+++ b/node_helper.js
@@ -44,8 +44,8 @@ module.exports = NodeHelper.create({
       return;
     }
 
-    let lat = config.lat || 52.36;
-    let lng = config.lng || 5.19;
+    let lat = config.lat || 0;
+    let lng = config.lng || 0;
     let alt = config.alt || 0;
     let days = config.days || 10;
     let minElevation = parseInt(config.minElevation) || 40;

--- a/node_helper.js
+++ b/node_helper.js
@@ -3,130 +3,109 @@
  *
  * By Dave Terrell
  * MIT Licensed.
+ *
+ * Modified to use N2YO API instead of NASA SpotTheStation
+ * (SpotTheStation was shut down on June 12, 2025)
+ *
+ * Requires a free N2YO API key from https://www.n2yo.com/api/
+ * Add `apiKey: 'YOUR_KEY'` to your module config in config.js
  */
 
-let NodeHelper = require('node_helper')
-const Parser = require('rss-parser');
+let NodeHelper = require('node_helper');
+const https = require('https');
+
+// ISS NORAD satellite ID
+const ISS_ID = 25544;
+
+// Compass directions lookup
+const DIRECTIONS = [
+  'N', 'NNE', 'NE', 'ENE',
+  'E', 'ESE', 'SE', 'SSE',
+  'S', 'SSW', 'SW', 'WSW',
+  'W', 'WNW', 'NW', 'NNW'
+];
+
+function degreesToCompass(deg) {
+  return DIRECTIONS[Math.round(deg / 22.5) % 16];
+}
 
 module.exports = NodeHelper.create({
-  
+
   requestInFlight: false,
 
   getData: function (config) {
     if (this.requestInFlight) return;
     this.requestInFlight = true;
 
-    let country = (config.country).replace(/ /g, "_");
-    let region = (config.region).replace(/ /g, "_");
-    let city = (config.city).replace(/ /g, "_");
+    if (!config.apiKey) {
+      console.error('MMM-ISS: No N2YO API key set. Add `apiKey: "YOUR_KEY"` to your config.');
+      this.sendSocketNotification('ERROR', 'No API key');
+      this.requestInFlight = false;
+      return;
+    }
 
-    let parser = new Parser();
-    let feedUrl = `https://spotthestation.nasa.gov/sightings/xml_files/${country}_${region}_${city}.xml`;
-    
+    let lat = config.lat || 52.36;
+    let lng = config.lng || 5.19;
+    let alt = config.alt || 0;
+    let days = config.days || 10;
+    let minElevation = parseInt(config.minElevation) || 40;
+
+    // N2YO visual passes endpoint
+    let url = `https://api.n2yo.com/rest/v1/satellite/visualpasses/${ISS_ID}/${lat}/${lng}/${alt}/${days}/${minElevation}/&apiKey=${config.apiKey}`;
+
     let self = this;
-    parser.parseURL(feedUrl, (err, feed) => {
-      if (err) {
-        self.sendSocketNotification('ERROR', err);
-      } else {
-        let sightings = self.parseFeed(feed, config);
-        self.sendSocketNotification('DATA_RESULT', sightings);
-      }
-      
+    https.get(url, (res) => {
+      let data = '';
+
+      res.on('data', chunk => data += chunk);
+
+      res.on('end', () => {
+        try {
+          let json = JSON.parse(data);
+
+          if (!json.passes || json.passes.length === 0) {
+            console.log('MMM-ISS: No passes found.');
+            self.sendSocketNotification('DATA_RESULT', {});
+          } else {
+            let result = self.parsePass(json.passes[0]);
+            self.sendSocketNotification('DATA_RESULT', result);
+          }
+        } catch (e) {
+          console.error('MMM-ISS: Error parsing N2YO response:', e);
+          self.sendSocketNotification('ERROR', e.message);
+        }
+
+        self.requestInFlight = false;
+      });
+    }).on('error', (err) => {
+      console.error('MMM-ISS: HTTP error:', err);
+      self.sendSocketNotification('ERROR', err.message);
       self.requestInFlight = false;
     });
   },
 
   socketNotificationReceived: function (notification, payload) {
     if (notification === 'GET_DATA') {
-      this.getData(payload)
+      this.getData(payload);
     }
   },
 
-  parseFeed: function (feed, config) {
-    let offset = new Date().getTimezoneOffset();
-    let plusMinus = offset >= 0 ? '-' : '+';
-    let stringOffset = "GMT" + plusMinus + ("0000" + (offset / 60 * 100)).substr(-4, 4);
-    let now = new Date();
+  parsePass: function (pass) {
+    // N2YO returns Unix timestamps (UTC)
+    let startTime = new Date(pass.startUTC * 1000);
+    let duration = Math.round(pass.duration / 60); // seconds → minutes
 
-    let sightings =
-      feed.items
-        .map(item => {
-          /**
-           * A sample item content:
-           * Date: Thursday Nov 19, 2020 <br/> Time: 7:12 PM <br/> Duration: less than 1 minute <br/> Maximum Elevation: 10° <br/> Approach: 10° above WNW <br/> Departure: 10° above WNW <br/> 
-           */
-          return item
-            .content
-            .split("<br/>")
-            .filter(e => e.trim())
-            .reduce((rv, el) => {
-              let e = el.split(/:(.+)/); // Split string at first colon
-
-              let prop = e[0].trim();
-              prop = prop.replace(" ", "_");
-
-              let data = e[1].trim();
-              data = data
-                .replace("less than ", "<")
-                .replace(" above ", "")
-                .replace(/minutes?/, "min");
-
-              rv[prop] = data;
-
-              return rv;
-            }, {});
-        })
-        // Remove Date and Time properties, replace with proper DateTime object
-        .map(sighting => {
-          let newDateTime = new Date([sighting.Date, sighting.Time, stringOffset].join(' '));
-
-          delete sighting.Date;
-          delete sighting.Time;
-
-          sighting.DateTime = newDateTime;
-
-          return sighting;
-        })
-        // Move directions (ex. WNW) out of Approach and Departure properties
-        .map(sighting => {
-          let splitParts = function (item) {
-            let parts = item.split("°");
-
-            return {
-              degree: parts[0],
-              direction: parts[1]
-            };
-          };
-
-          let app = splitParts(sighting.Approach);
-          sighting.Approach = app.degree + "°";
-          sighting.Approach_Direction = app.direction;
-
-          let dep = splitParts(sighting.Departure);
-          sighting.Departure = dep.degree + "°";
-          sighting.Departure_Direction = dep.direction;
-
-          return sighting;
-        })
-        // Remove sightings that are in the past
-        .filter(sighting => sighting.DateTime >= now)
-        // Remove sightings that are too low in the sky 
-        .filter(sighting => parseInt(sighting.Maximum_Elevation) >= config.minElevation)
-        // Ensure we're listed by date
-        .sort((a, b) => a.DateTime - b.DateTime)[0];
-    
-    
-    if (!sightings || Object.keys(sightings).length <= 0) return {};
+    let durationStr = duration < 1 ? '<1 min' : duration + ' min';
 
     return {
-      date: sightings.DateTime.toLocaleDateString([], { weekday: "short", month: "short", day: "numeric" }),
-      time: sightings.DateTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      visible: sightings.Duration,
-      maxHeight: sightings.Maximum_Elevation,
-      appears: sightings.Approach,
-      appearsDirection: sightings.Approach_Direction,
-      disappears: sightings.Departure,
-      disappearsDirection: sightings.Departure_Direction,
+      date: startTime.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' }),
+      time: startTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      visible: durationStr,
+      maxHeight: pass.maxEl + '°',
+      appears: pass.startEl + '°',
+      appearsDirection: degreesToCompass(pass.startAz),
+      disappears: pass.endEl + '°',
+      disappearsDirection: degreesToCompass(pass.endAz),
     };
   }
 });


### PR DESCRIPTION
Fix: Replace SpotTheStation with N2YO API

NASA shut down SpotTheStation on June 12, 2025, breaking all data fetches. This replaces the RSS feed parser with the N2YO visual passes API. A free API key from n2yo.com is required — add apiKey: 'YOUR_KEY' to the module config. The output payload is unchanged, so no modifications to MMM-ISS.js or templates are needed.